### PR TITLE
Added support for Vorwerk VR200 robot

### DIFF
--- a/NeatoBotvacClient.php
+++ b/NeatoBotvacClient.php
@@ -15,8 +15,15 @@ class NeatoBotvacClient {
 	protected $baseUrl = "https://beehive.neatocloud.com";
 	public $token;
 
-	public function __construct($token = false) {
+	public function __construct($token = false, $vendor="neato") {
 		$this->token = $token;
+
+		switch ($vendor) {
+
+			case "vorwerk":
+						$this->baseUrl = "https://vorwerk-beehive-production.herokuapp.com";
+						break;
+		}
 	}
 
 	public function authorize($email, $password, $force = false) {

--- a/NeatoBotvacRobot.php
+++ b/NeatoBotvacRobot.php
@@ -16,9 +16,14 @@ class NeatoBotvacRobot {
 	protected $serial;
 	protected $secret;
 
-	public function __construct($serial, $secret) {
+	public function __construct($serial, $secret, $model = "default" ) {
 		$this->serial = $serial;
 		$this->secret = $secret;
+
+		if ($model == "VR200") {
+
+			$this->baseUrl = "https://nucleo.ksecosys.com:4443/vendors/vorwerk/robots/";
+		}
 	}
 
 	public function getState() {

--- a/examples/client.php
+++ b/examples/client.php
@@ -23,7 +23,7 @@ if($auth !== false) {
 
 	if($result !== false) {
 		foreach ($result["robots"] as $robot) {
-			$robots[] = new NeatoBotvacRobot($robot["serial"], $robot["secret_key"]);
+			$robots[] = new NeatoBotvacRobot($robot["serial"], $robot["secret_key"], $robot["model"] );
 		}
 	}
 } else {


### PR DESCRIPTION
Added a mode which allows users to optionally specify a Vorwerk VR200 robot. This model is based on the Neato Robot but uses different URLs for the web services.

I've tested it with my VR200 but could not test if the code destroys existing Neato functionalities.